### PR TITLE
Add protection fields on case.patient.household

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ file. This file is structured according to http://keepachangelog.com/
 - `contact.preferredLanguages` as array in `case`
 - Mandatory foreign key `personId` on `person.contact.sourceCases`
 - Add multiple patients per call feature fields to `case` (`sameCallPatients` and `callId`)
+- `patient.household.child`, `patient.household.pregnantWoman`, and `patient.household.disabledPerson` on `case` schema
 
 ### Changed
 - `relative` is belongs to the Person now, not just the Case.

--- a/schemas/Case.json
+++ b/schemas/Case.json
@@ -77,7 +77,8 @@
         "adminDivision1": { "type": ["string", "number"] },
         "adminDivision2": { "type": ["string", "number"] },
         "adminDivision3": { "type": ["string", "number"] },
-        "location": { "$ref": "#/definitions/location" }
+        "location": { "$ref": "#/definitions/location" },
+        "household": { "$ref": "#/definitions/household" }
       }
     },
     "response": {
@@ -108,7 +109,15 @@
         "name": { "type": "string" }
       },
       "required": ["id", "name"]
-    }
+    },
+    "household": {
+      "type": "object",
+      "properties": {
+        "child": { "type": "boolean" },
+        "disabledPerson": { "type": "boolean" },
+        "pregnantWoman": { "type": "boolean" }
+      }
+    }    
   },
 
   "required": [

--- a/schemas/Case.json
+++ b/schemas/Case.json
@@ -78,7 +78,14 @@
         "adminDivision2": { "type": ["string", "number"] },
         "adminDivision3": { "type": ["string", "number"] },
         "location": { "$ref": "#/definitions/location" },
-        "household": { "$ref": "#/definitions/household" }
+        "household": {
+          "type": "object",
+          "properties": {
+            "child":          { "type": "boolean" },
+            "disabledPerson": { "type": "boolean" },
+            "pregnantWoman":  { "type": "boolean" }
+          }
+        }
       }
     },
     "response": {
@@ -109,15 +116,7 @@
         "name": { "type": "string" }
       },
       "required": ["id", "name"]
-    },
-    "household": {
-      "type": "object",
-      "properties": {
-        "child": { "type": "boolean" },
-        "disabledPerson": { "type": "boolean" },
-        "pregnantWoman": { "type": "boolean" }
-      }
-    }    
+    }
   },
 
   "required": [

--- a/test/examples/case/1.json
+++ b/test/examples/case/1.json
@@ -12,6 +12,10 @@
   "patient": {
     "doc_type": "patient",
     "status": "alive",
+    "household": {
+      "pregnantWoman": true,
+      "child": true
+    },
     "symptoms": {
       "common": {
         "fever": false,


### PR DESCRIPTION
This change introduces a `household` object on the `case.patient`.

It's used to store information to about necessary protection services for the case.

Related to protection fields change: eHealthAfrica/sl-ebola-call-admin/issues/511