### PR TITLE
Add follow up data model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ file. This file is structured according to http://keepachangelog.com/
 ### Added
 - Added schema for a `FollowUp`. Going forward we'll split out the followups from
   `Person` into this separate document which can be found by their `_id`, which will
-  be in the format `contactId/dateOfVisit`.
+  be in the format `personId/dateOfVisit`.
 
 ## 1.14.0 - 2015-04-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ file. This file is structured according to http://keepachangelog.com/
 
 ---
 
+## [Unreleased] - [Unreleased]
+### Added
+- Added schema for a `FollowUp`. Going forward we'll split out the followups from
+  `Person` into this separate document which can be found by their `_id`, which will
+  be in the format `contactId/dateOfVisit`.
+
 ## 1.14.0 - 2015-04-24
 ### Added
 - Person: `otherNames` & `gender` is now required to match reality with Sense

--- a/schemas/FollowUp.json
+++ b/schemas/FollowUp.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "FollowUp",
+  "description": "A single follow up of a person",
+  "type": "object",
+  "properties": {
+    "_id": { "type": "string" },
+    "doc_type": { "type": "string", "pattern": "^followup$" },
+    "version": { "type": "string", "format": "semver" },
+    "status": { "enum": ["incomplete", "complete"] },
+    "incompleteReason": {
+      "enum": [
+        "food-distribution-incomplete",
+        "no-food-distribution",
+        "gone-to-work",
+        "resistance",
+        "travelling",
+        "other"
+      ]
+    },
+    "interviewer": { "$ref": "#/definitions/connectedPerson" },
+    "comment": { "type": "string" },
+    "isSymptomatic": { "type": "boolean" },
+    "symptoms": { "$ref": "#/definitions/symptoms" },
+    "geoInfo": { "type": "object", "properties": {
+      "coords": { "type": "object", "properties": {
+        "longitude": { "type": "number" },
+        "latitude": { "type": "number" }
+      }}
+    }},
+    "deviceId": { "type": "string" },
+    "dateOfVisit": { "type": "string", "format": "date-time" },
+    "contactId": { "type": "string" }
+  },
+  "definitions": {
+    "symptoms": {
+      "type": "object",
+      "properties": {
+        "temperature": { "type": "number"},
+        "fever": { "type": "boolean" },
+        "abdominal_pains": { "type": "boolean" },
+        "articular_pain": { "type": "boolean" },
+        "cough": { "type": "boolean" },
+        "diarrhea": { "type": "boolean" },
+        "difficulty_breathing": { "type": "boolean" },
+        "difficulty_swallowing": { "type": "boolean" },
+        "headache": { "type": "boolean" },
+        "hiccups": { "type": "boolean" },
+        "intense_fatigue": { "type": "boolean" },
+        "loss_of_appetite": { "type": "boolean" },
+        "muscular_pain": { "type": "boolean" },
+        "nausea_vomiting": { "type": "boolean" },
+        "sore_throat": { "type": "boolean" },
+        "thoracic_pain": { "type": "boolean" },
+        "unexplained_bleedings": { "type": "boolean" },
+        "rash": { "type": "boolean" },
+        "red_eyes": { "type": "boolean" },
+        "other_symptoms": { "type": "boolean" },
+        "other": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+
+    "connectedPerson": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "faker": "name.findName"},
+        "phone": { "type": "string", "chance": { "phone": { "country": "uk" }}}
+      }
+    }
+  },
+  "required": [
+    "_id",
+    "doc_type",
+    "version",
+    "dateOfVisit",
+    "status"
+  ]
+}

--- a/schemas/FollowUp.json
+++ b/schemas/FollowUp.json
@@ -30,7 +30,7 @@
     }},
     "deviceId": { "type": "string" },
     "dateOfVisit": { "type": "string", "format": "date-time" },
-    "contactId": { "type": "string" }
+    "personId": { "type": "string" }
   },
   "definitions": {
     "symptoms": {
@@ -74,6 +74,7 @@
     "doc_type",
     "version",
     "dateOfVisit",
+    "personId",
     "status"
   ]
 }

--- a/schemas/FollowUp.json
+++ b/schemas/FollowUp.json
@@ -4,7 +4,7 @@
   "description": "A single follow up of a person",
   "type": "object",
   "properties": {
-    "_id": { "type": "string" },
+    "_id": { "type": "string", "pattern": "^[^/]+/[^/]+$" },
     "doc_type": { "type": "string", "pattern": "^followup$" },
     "version": { "type": "string", "format": "semver" },
     "status": { "enum": ["incomplete", "complete"] },

--- a/schemas/index.js
+++ b/schemas/index.js
@@ -6,6 +6,7 @@ module.exports = {
   'deliveryRound': require('./DeliveryRound.json'),
   'driver': require('./Driver.json'),
   'facilityRound': require('./FacilityRound.json'),
+  'followup': require('./FollowUp.json'),
   'packingList': require('./PackingList.json'),
   'person': require('./Person.json'),
   'pickedProduct': require('./PickedProduct.json'),

--- a/test/examples/followup/1.json
+++ b/test/examples/followup/1.json
@@ -28,5 +28,6 @@
     "name": "test interviewer"
   },
   "deviceId": "e1234",
-  "status": "complete"
+  "status": "complete",
+  "contactId": "7cdbd7e2-523a-4c1a-c128-f99966759ce8"
 }

--- a/test/examples/followup/1.json
+++ b/test/examples/followup/1.json
@@ -1,0 +1,32 @@
+{
+  "_id": "a4533cab-61bf-4645-9473-93e8df9149a4/2014-08-22T13:36:25.263Z",
+  "_rev": "3-24d7258aa284524d083ab1ff2f4bc997",
+  "doc_type": "followup",
+  "version": "0.0.0",
+  "symptoms": {
+    "headache": false,
+    "temperature": 36.50,
+    "other": "some other",
+    "loss_of_appetite": true
+  },
+  "dateOfVisit": "2014-08-22T13:36:25.263Z",
+  "geoInfo": {
+    "timestamp": 1408715750330,
+    "coords": {
+      "speed": null,
+      "heading": null,
+      "altitudeAccuracy": null,
+      "accuracy": 2052,
+      "altitude": null,
+      "longitude": 0.3676124,
+      "latitude": 0.51913
+    }
+
+  },
+  "comment": "some comment",
+  "interviewer": {
+    "name": "test interviewer"
+  },
+  "deviceId": "e1234",
+  "status": "complete"
+}

--- a/test/examples/followup/1.json
+++ b/test/examples/followup/1.json
@@ -1,5 +1,5 @@
 {
-  "_id": "a4533cab-61bf-4645-9473-93e8df9149a4/2014-08-22T13:36:25.263Z",
+  "_id": "7cdbd7e2-523a-4c1a-c128-f99966759ce8/2014-08-22T13:36:25.263Z",
   "_rev": "3-24d7258aa284524d083ab1ff2f4bc997",
   "doc_type": "followup",
   "version": "0.0.0",
@@ -29,5 +29,5 @@
   },
   "deviceId": "e1234",
   "status": "complete",
-  "contactId": "7cdbd7e2-523a-4c1a-c128-f99966759ce8"
+  "personId": "7cdbd7e2-523a-4c1a-c128-f99966759ce8"
 }

--- a/test/followup.js
+++ b/test/followup.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var assert = require('assert');
+var dataModel = require('../index');
+
+var example1 = require('./examples/followup/1.json');
+
+function clone(doc) {
+  return JSON.parse(JSON.stringify(doc));
+}
+
+var statusRequired = clone(example1);
+
+describe('person', function() {
+
+  it('validates the first example', function() {
+    var errors = dataModel.validate(example1);
+    assert.equal(errors, null, JSON.stringify(errors));
+  });
+
+  it('complains when required properties are missing', function() {
+    var errors = dataModel.validate({});
+    assert(errors && errors.length > 0);
+  });
+
+  it('complains when required property is not there', function() {
+    statusRequired.status = '';
+    var errors = dataModel.validate(statusRequired);
+    assert(errors && errors.length > 0);
+  });
+});


### PR DESCRIPTION
Going forward we'll split out the followups from `Person` into this separate document which can be found by their `_id`, which will be in the format `contactId/dateOfVisit`. We also save`contactId` and `dateOfVisit` directly in the document, but this is up for discussion. I didn't do a fancy RegEx for the `_id` as this is quite complex. But the way we'll have the id allows us for easy range queries (get all followups of a person) and also allows ordering by Couch (simply by ordering by key).

/cc @jo 