### PR TITLE
add a `cancelled` status for callbacks - eHealthAfrica/sl-ebola-call-…

### DIFF
--- a/schemas/Callback.json
+++ b/schemas/Callback.json
@@ -12,7 +12,10 @@
       "username": { "type": "string" },
       "fullName": { "type": "string" }
     },
-    "status": { "enum": ["pending", "rescheduled", "done"] },
+    "status": { "enum": ["pending", "rescheduled", "done", "cancelled"] },
+    "cancelledDetails": {
+      "reason": { "type": "string" }
+    },
     "createdOn": {
       "type": "string",
       "format": "date-time"

--- a/test/callback.js
+++ b/test/callback.js
@@ -4,10 +4,15 @@ var assert = require('assert');
 var dataModel = require('../index');
 
 var example1 = require('./examples/callback/1.json');
+var example2 = require('./examples/callback/2.json');
 
 describe('callback', function() {
   it('validates the first example', function() {
     var errors = dataModel.validate(example1);
+    assert.equal(errors, null, JSON.stringify(errors));
+  });
+  it('validates the second example', function() {
+    var errors = dataModel.validate(example2);
     assert.equal(errors, null, JSON.stringify(errors));
   });
 });

--- a/test/examples/callback/2.json
+++ b/test/examples/callback/2.json
@@ -1,0 +1,18 @@
+{
+   "_id": "05070a875cdb4d9a147e6f9dcea7cbb3:2015-09-23T13:19:01.161Z",
+   "_rev": "4-3938ad7b2d32dd72ce6b90e8605cebff",
+   "callId": "05070a875cdb4d9a147e6f9dcea7cbb3",
+   "reason": "Call Nature: undefined",
+   "author": {
+       "username": "analyst",
+       "fullName": "analyst"
+   },
+   "doc_type": "callback",
+   "status": "cancelled",
+   "cancelledDetails": {
+     "reason": "busy"
+   },
+   "createdOn": "2015-09-23T13:19:01.161Z",
+   "version": "1.21.3",
+   "scheduledAt": "2015-09-23T13:19:01.161Z"
+}


### PR DESCRIPTION
Okay done. This is the fixed version of #85. I think that tests should be more strict and fail when there is an object which is not in the schema, anyway it is probably not worth working on this since the data models seem not often used recently